### PR TITLE
Add image tag mutability variable to ecr module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,9 @@ module "ecr" {
   version = "0.32.2"
   enabled = var.codepipeline_enabled
 
-  attributes          = ["ecr"]
-  scan_images_on_push = var.ecr_scan_images_on_push
+  attributes           = ["ecr"]
+  scan_images_on_push  = var.ecr_scan_images_on_push
+  image_tag_mutability = var.ecr_image_tag_mutability
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -896,3 +896,9 @@ variable "deployment_controller_type" {
   description = "Type of deployment controller. Valid values are CODE_DEPLOY and ECS"
   default     = "ECS"
 }
+
+variable "ecr_image_tag_mutability" {
+  type        = string
+  default     = "IMMUTABLE"
+  description = "The tag mutability setting for the ecr repository. Must be one of: `MUTABLE` or `IMMUTABLE`"
+}


### PR DESCRIPTION
## what
- Adds the ability to set the ecr image tag mutability variable rather than relying on the default value of `IMMUATABLE`

## why
- Need the ability to set the ecr image tag mutability as `MUTABLE` in certain instances

## references
- Works on https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/119

